### PR TITLE
added internal dnsseed for intranets

### DIFF
--- a/mbhd-core/src/main/java/org/multibit/hd/core/services/BitcoinNetworkService.java
+++ b/mbhd-core/src/main/java/org/multibit/hd/core/services/BitcoinNetworkService.java
@@ -1564,6 +1564,7 @@ public class BitcoinNetworkService extends AbstractService {
   private void createNewPeerGroup(Wallet wallet, boolean useFastCatchup) throws TimeoutException {
     String[] dnsSeeds = new String[]{
                      /* "seed.bitcoin.sipa.be",        // Pieter Wuille - not reachable */
+      "dnsseed.internal",            // Internal Intranet DNS seed for environments without direct internet access.
       "dnsseed.bluematt.me",         // Matt Corallo
       "dnsseed.bitcoin.dashjr.org",  // Luke Dashjr
       "seed.bitcoinstats.com",       // Chris Decker


### PR DESCRIPTION
A simple way to add support for multibit on intranets that have a bitcoind node running inside the LAN but no internet access. Just create a dnsseed.internal address in your internal DNS tree that points to the bitcoin node. 

MultibitHD should probably have support to configure peers explicitly as multibit classic did, but it seems that functionality is not present yet - and even if it was having an internal DNS seed is a fairly easy way to configure it and is also a very easy change to make with no major downsides.