### PR TITLE
Catch Exception instead of Throwable

### DIFF
--- a/mbhd-core/src/main/java/org/multibit/hd/core/error_reporting/ExceptionHandler.java
+++ b/mbhd-core/src/main/java/org/multibit/hd/core/error_reporting/ExceptionHandler.java
@@ -105,8 +105,8 @@ public class ExceptionHandler extends EventQueue implements Thread.UncaughtExcep
             nativeApplicationClass.getDeclaredConstructor(boolean.class).newInstance(true);
           } catch (IllegalStateException ise) {
             log.error("Unable to create dialog as one is already being shown");
-          } catch (Throwable t1) {
-            log.error("Unable to use standard error reporting dialog.", t1);
+          } catch (Exception e) {
+            log.error("Unable to use standard error reporting dialog.", e);
             try {
               // This should never happen due to static binding of the Swing library
               JOptionPane.showMessageDialog(null,
@@ -118,8 +118,8 @@ public class ExceptionHandler extends EventQueue implements Thread.UncaughtExcep
                 JOptionPane.ERROR_MESSAGE);
               // Fire a hard shutdown after dialog closes with emergency fallback
               CoreEvents.fireShutdownEvent(ShutdownEvent.ShutdownType.HARD);
-            } catch (Throwable t2) {
-              log.error("Unable to use fallback error reporting dialog. Forcing immediate shutdown.", t2);
+            } catch (Exception e1) {
+              log.error("Unable to use fallback error reporting dialog. Forcing immediate shutdown.", e1);
               // Safest option at this point is an emergency shutdown
               System.exit(-1);
             }
@@ -153,21 +153,21 @@ public class ExceptionHandler extends EventQueue implements Thread.UncaughtExcep
             nativeApplicationClass.getDeclaredConstructor(boolean.class).newInstance(false);
           } catch (IllegalStateException ise) {
             log.error("Unable to create dialog as one is already being shown");
-          } catch (Throwable t1) {
-            log.error("Unable to use standard error reporting dialog.", t1);
+          } catch (Exception e) {
+            log.error("Unable to use standard error reporting dialog.", e);
             try {
               // This should never happen due to static binding of the Swing library
               JOptionPane.showMessageDialog(null,
                 "Oh Snap!\n\n"
                   + "The error reporting system has failed with the following message:\n"
-                  + WordUtils.wrap(t1.getMessage(), 30)
+                  + WordUtils.wrap(e.getMessage(), 30)
                   + "\n\nMultiBit HD will exit and you should report this error to the MultiBit HD developers.",
                 "Error",
                 JOptionPane.ERROR_MESSAGE);
               // Fire a hard shutdown after dialog closes with emergency fallback
               CoreEvents.fireShutdownEvent(ShutdownEvent.ShutdownType.HARD);
-            } catch (Throwable t2) {
-              log.error("Unable to use fallback error reporting dialog. Forcing immediate shutdown.", t2);
+            } catch (Exception e1) {
+              log.error("Unable to use fallback error reporting dialog. Forcing immediate shutdown.", e1);
               // Safest option at this point is an emergency shutdown
               System.exit(-1);
             }
@@ -181,8 +181,8 @@ public class ExceptionHandler extends EventQueue implements Thread.UncaughtExcep
   protected void dispatchEvent(AWTEvent newEvent) {
     try {
       super.dispatchEvent(newEvent);
-    } catch (Throwable t) {
-      handleThrowable(t);
+    } catch (Exception e) {
+      handleThrowable(e);
     }
   }
 
@@ -383,7 +383,6 @@ public class ExceptionHandler extends EventQueue implements Thread.UncaughtExcep
         errorReportLogEntryList.add(entry.get());
       }
     }
-
     // Build the error report including basic operating system information
     ErrorReport errorReport = new ErrorReport();
     errorReport.setOsName(OSUtils.getOsName());

--- a/mbhd-core/src/main/java/org/multibit/hd/core/services/CoreServices.java
+++ b/mbhd-core/src/main/java/org/multibit/hd/core/services/CoreServices.java
@@ -689,8 +689,8 @@ public class CoreServices {
       // Wrap the client in a service for high level API suitable for downstream applications
       return Optional.of(new HardwareWalletService(client));
 
-    } catch (Throwable throwable) {
-      log.warn("Could not create the hardware wallet.", throwable);
+    } catch (Exception e) {
+      log.warn("Could not create the hardware wallet.", e);
       return Optional.absent();
     }
   }
@@ -713,8 +713,8 @@ public class CoreServices {
       // Wrap the client in a service for high level API suitable for downstream applications
       return Optional.of(new HardwareWalletService(client));
 
-    } catch (Throwable throwable) {
-      log.warn("Could not create the hardware wallet.", throwable);
+    } catch (Exception e) {
+      log.warn("Could not create the hardware wallet.", e);
       return Optional.absent();
     }
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1181 - “ Throwable and Error should not be caught”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1181
Please let me know if you have any questions.
Ayman Abdelghany.